### PR TITLE
Bugfix status created

### DIFF
--- a/src/Job/Status.php
+++ b/src/Job/Status.php
@@ -128,7 +128,7 @@ class Status
 
         $this->setAttributes(array(
             'status'  => self::STATUS_WAITING,
-            'started' => time(),
+            'created' => time(),
             'updated' => time()
         ));
     }


### PR DESCRIPTION
I discovered that the status is created with the attribute 'started' but later the attribute 'created' is used.
I assume it should be 'created' and not 'started' as this would match the existing logic.

Fixed it and also wrote a test.
