### PR TITLE
Add prefix for all commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ use Resque\Resque;
 use Predis\Client;
 
 $resque = new Resque(new Client());
-$resque->enqueue('default_queue', 'App\Job', array('foo' => 'bar'), true);
+$resque->enqueue('default_queue', \App\Job::class, array('foo' => 'bar'), true);
 ```
 
 In order the arguments are: queue, job class, job payload, whether to enable tracking.

--- a/src/Console/EnqueueCommand.php
+++ b/src/Console/EnqueueCommand.php
@@ -17,7 +17,7 @@ class EnqueueCommand extends Command
         parent::configure();
 
         $this
-            ->setName('enqueue')
+            ->setName('queue:enqueue')
             ->setDescription('Enqueues a job into a queue')
             ->addArgument(
                 'queue',
@@ -49,6 +49,9 @@ class EnqueueCommand extends Command
                 InputOption::VALUE_NONE,
                 'If present, the job will be tracked'
             );
+
+        // Add old command name as alias
+        $this->setAliases(['enqueue']);
     }
 
     /**

--- a/src/Console/WorkerCommand.php
+++ b/src/Console/WorkerCommand.php
@@ -17,7 +17,7 @@ class WorkerCommand extends Command
         parent::configure();
 
         $this
-            ->setName('worker')
+            ->setName('queue:worker')
             ->setDescription('Runs a Resque worker')
             ->addOption(
                 'queue',
@@ -32,6 +32,9 @@ class WorkerCommand extends Command
                 'Interval in seconds to wait for between reserving jobs',
                 5
             );
+
+        // Add old command name as alias
+        $this->setAliases(['worker']);
     }
 
     /**

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -403,6 +403,7 @@ class Worker implements LoggerAwareInterface
             $queue
         );
 
+        $this->logger->error($exception->getMessage());
         $this->getResque()->getStatistic('failed')->incr();
         $this->getStatistic('failed')->incr();
     }


### PR DESCRIPTION
I have two little improvements. 
- The Worker should log to console if a job is failing
- worker and enque doesn't have a namespace. I fixed, but there is an alias for BC.

What do you think about that? 
