### PR TITLE
Fix pcntl_signal work for PHP7

### DIFF
--- a/src/Worker.php
+++ b/src/Worker.php
@@ -1,4 +1,5 @@
 <?php
+declare(ticks = 1);
 
 namespace Resque;
 
@@ -546,7 +547,6 @@ class Worker implements LoggerAwareInterface
             return;
         }
 
-        declare(ticks = 1);
         pcntl_signal(SIGTERM, array($this, 'shutDownNow'));
         pcntl_signal(SIGINT, array($this, 'shutDownNow'));
         pcntl_signal(SIGQUIT, array($this, 'shutdown'));


### PR DESCRIPTION
Moved declare(ticks = 1); to beginning of the file, that fix pcntl_signal work for PHP7.